### PR TITLE
Recognize the "navigate-to" nav directive

### DIFF
--- a/csp.ts
+++ b/csp.ts
@@ -262,6 +262,7 @@ export enum Directive {
   // Navigation directives
   FORM_ACTION = 'form-action',
   FRAME_ANCESTORS = 'frame-ancestors',
+  NAVIGATE_TO = 'navigate-to',
 
   // Reporting directives
   REPORT_TO = 'report-to',


### PR DESCRIPTION
Recognize the
[navigate-to](https://w3c.github.io/webappsec-csp/#directive-navigate-to)
CSPv3 navigation directive to restrict document-initiated navigation.

Closes #34