### PR TITLE
Support wildcard as port number

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -42,7 +42,9 @@ export function getHostname(url: string): string {
   const hostname =
       new URL(
           'https://' +
-          getSchemeFreeUrl(url).replace('*', 'wildcard_placeholder'))
+      getSchemeFreeUrl(url)
+        .replace(':*', '')  // Remove wildcard port
+        .replace('*', 'wildcard_placeholder'))
           .hostname.replace('wildcard_placeholder', '*');
 
   // Some browsers strip the brackets from IPv6 addresses when you access the

--- a/utils.ts
+++ b/utils.ts
@@ -80,7 +80,9 @@ export function matchWildcardUrls(
   // encapsulated in this function such that callers of this function do not
   // have to worry about this detail.
   const cspUrl =
-      new URL(setScheme(cspUrlString.replace('*', 'wildcard_placeholder')));
+      new URL(setScheme(cspUrlString
+        .replace(':*', '')  // Remove wildcard port
+        .replace('*', 'wildcard_placeholder')));
   const listOfUrls = listOfUrlStrings.map(u => new URL(setScheme(u)));
   const host = cspUrl.hostname.toLowerCase();
   const hostHasWildcard = host.startsWith('wildcard_placeholder.');

--- a/utils_test.ts
+++ b/utils_test.ts
@@ -85,6 +85,14 @@ describe('Test Utils', () => {
     expect(getHostname('https://www.google.com')).toBe('www.google.com');
   });
 
+  it('GetHostnamePort', () => {
+    expect(getHostname('https://www.google.com:8080')).toBe('www.google.com');
+  });
+
+  it('GetHostnameWildcardPort', () => {
+    expect(getHostname('https://www.google.com:*')).toBe('www.google.com');
+  });
+
   it('GetHostnameNoProtocol', () => {
     expect(getHostname('www.google.com')).toBe('www.google.com');
   });


### PR DESCRIPTION
If a wildcard is used as a port number, for example `default-src http://example.com:*`, it will cause an error like shown below. This pull request will fix this.

```
> parsed = new parser.CspParser("default-src http://example.com:*").csp;
Csp { directives: { 'default-src': [ 'http://example.com:*' ] } }
> new evaluator.CspEvaluator(parsed).evaluate();
Uncaught TypeError [ERR_INVALID_URL]: Invalid URL
    at __node_internal_captureLargerStackTrace (node:internal/errors:465:5)
    at new NodeError (node:internal/errors:372:5)
    at onParseError (node:internal/url:563:9)
    at new URL (node:internal/url:643:5)
    at Object.matchWildcardUrls (/tmp/node_modules/csp_evaluator/dist/utils.js:28:20)
    at checkScriptAllowlistBypass (/tmp/node_modules/csp_evaluator/dist/checks/security_checks.js:151:37)
    at CspEvaluator.evaluate (/tmp/node_modules/csp_evaluator/dist/evaluator.js:43:50) {
  input: 'https://example.com:wildcard_placeholder',
  code: 'ERR_INVALID_URL'
}
```