### PR TITLE
Add webrtc directive

### DIFF
--- a/csp.ts
+++ b/csp.ts
@@ -214,6 +214,8 @@ export enum Keyword {
   UNSAFE_HASHED_ATTRIBUTES = '\'unsafe-hashed-attributes\'',
   UNSAFE_HASHES = '\'unsafe-hashes\'',
   REPORT_SAMPLE = '\'report-sample\''
+  BLOCK = '\'block\''
+  ALLOW = '\'allow\''
 }
 
 
@@ -276,6 +278,7 @@ export enum Directive {
   TRUSTED_TYPES = 'trusted-types',
   // https://github.com/WICG/trusted-types
   REQUIRE_TRUSTED_TYPES_FOR = 'require-trusted-types-for'
+  WEBRTC = 'webrtc',
 }
 
 /**


### PR DESCRIPTION
Adds basic support for recognizing the "webrtc" directive, as specified
by CSP Level 3: https://w3c.github.io/webappsec-csp/#directive-webrtc