### PR TITLE
Remove Deprecated LinkedIn JSONP Endpoint

### DIFF
--- a/allowlist_bypasses/json/jsonp.json
+++ b/allowlist_bypasses/json/jsonp.json
@@ -84,7 +84,6 @@
   "//graph.facebook.com/1/",
   "//fellowes.ugc.bazaarvoice.com/data/reviews.json",
   "//widgets.pinterest.com/v3/pidgets/boards/ciciwin/hedgehog-squirrel-crafts/pins/",
-  "//www.linkedin.com/countserv/count/share",
   "//se.wikipedia.org/w/api.php",
   "//cse.google.com/api/007627024705277327428/cse/r3vs7b0fcli/queries/js",
   "//relap.io/api/v2/similar_pages_jsonp.js",

--- a/allowlist_bypasses/jsonp.ts
+++ b/allowlist_bypasses/jsonp.ts
@@ -117,7 +117,6 @@ export const URLS: string[] = [
   '//graph.facebook.com/1/',
   '//fellowes.ugc.bazaarvoice.com/data/reviews.json',
   '//widgets.pinterest.com/v3/pidgets/boards/ciciwin/hedgehog-squirrel-crafts/pins/',
-  '//www.linkedin.com/countserv/count/share',
   '//se.wikipedia.org/w/api.php',
   '//cse.google.com/api/007627024705277327428/cse/r3vs7b0fcli/queries/js',
   '//relap.io/api/v2/similar_pages_jsonp.js',


### PR DESCRIPTION
The LinkedIn JSONP endpoint documented in CSP Evaluator is not available since 2018: https://developer.linkedin.com/blog/posts/2018/deprecating-the-inshare-counter