### PR TITLE
Remove deprecated Twitter JSONP Endpoint

### DIFF
--- a/allowlist_bypasses/json/jsonp.json
+++ b/allowlist_bypasses/json/jsonp.json
@@ -99,7 +99,7 @@
   "//autocomplete.travelpayouts.com/avia",
   "//www.googleapis.com/freebase/v1/topic/m/0344_",
   "//mts1.googleapis.com/mapslt/ft",
-  "//api.twitter.com/1/statuses/oembed.json",
+  "//publish.twitter.com/oembed",
   "//fast.wistia.com/embed/medias/o75jtw7654.json",
   "//partner.googleadservices.com/gampad/ads",
   "//pass.yandex.ru/services",

--- a/allowlist_bypasses/jsonp.ts
+++ b/allowlist_bypasses/jsonp.ts
@@ -132,7 +132,7 @@ export const URLS: string[] = [
   '//autocomplete.travelpayouts.com/avia',
   '//www.googleapis.com/freebase/v1/topic/m/0344_',
   '//mts1.googleapis.com/mapslt/ft',
-  '//api.twitter.com/1/statuses/oembed.json',
+  "//publish.twitter.com/oembed",
   '//fast.wistia.com/embed/medias/o75jtw7654.json',
   '//partner.googleadservices.com/gampad/ads',
   '//pass.yandex.ru/services',

--- a/allowlist_bypasses/jsonp.ts
+++ b/allowlist_bypasses/jsonp.ts
@@ -132,7 +132,7 @@ export const URLS: string[] = [
   '//autocomplete.travelpayouts.com/avia',
   '//www.googleapis.com/freebase/v1/topic/m/0344_',
   '//mts1.googleapis.com/mapslt/ft',
-  "//publish.twitter.com/oembed",
+  '//publish.twitter.com/oembed',
   '//fast.wistia.com/embed/medias/o75jtw7654.json',
   '//partner.googleadservices.com/gampad/ads',
   '//pass.yandex.ru/services',


### PR DESCRIPTION
Twitter JSONP Endpoint is outdated compared to [oEmbed API](https://developer.twitter.com/en/docs/twitter-for-websites/timelines/guides/oembed-api).

Replace it with https://publish.twitter.com/oembed. Example https://jsfiddle.net/kfv2qr9e/