### PR TITLE
Remove dev.virtualearth.net

### DIFF
--- a/allowlist_bypasses/json/jsonp.json
+++ b/allowlist_bypasses/json/jsonp.json
@@ -75,7 +75,6 @@
   "//wslocker.ru/client/user.chk.php",
   "//community.adobe.com/CommunityPod/getJSON",
   "//maps.google.lv/maps/vt",
-  "//dev.virtualearth.net/REST/V1/Imagery/Metadata/AerialWithLabels/26.318581",
   "//awaps.yandex.ru/10/8938/02400400.",
   "//a248.e.akamai.net/h5.hulu.com/h5.mp4",
   "//nominatim.openstreetmap.org/",

--- a/allowlist_bypasses/jsonp.ts
+++ b/allowlist_bypasses/jsonp.ts
@@ -108,7 +108,6 @@ export const URLS: string[] = [
   '//wslocker.ru/client/user.chk.php',
   '//community.adobe.com/CommunityPod/getJSON',
   '//maps.google.lv/maps/vt',
-  '//dev.virtualearth.net/REST/V1/Imagery/Metadata/AerialWithLabels/26.318581',
   '//awaps.yandex.ru/10/8938/02400400.',
   '//a248.e.akamai.net/h5.hulu.com/h5.mp4',
   '//nominatim.openstreetmap.org/',


### PR DESCRIPTION
This endpoint now validates JSONP callback and is no longer vulnerable. 

Can we remove it from the list? Or are there are other known vulnerable endpoints behind dev.virtualearth.net that still need fixing? Thanks. 

![image](https://github.com/google/csp-evaluator/assets/37370256/7f2050d6-1de0-4731-9928-891ade233604)
