### PR TITLE
Add the prefetch-src as a deprecated directive

### DIFF
--- a/checks/security_checks.ts
+++ b/checks/security_checks.ts
@@ -497,6 +497,15 @@ export function checkDeprecatedDirective(parsedCsp: Csp): Finding[] {
             'Please, use the Cross Origin Opener Policy header instead.',
         Severity.INFO, Directive.DISOWN_OPENER));
   }
+  
+  // More details: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src
+  if (Directive.PREFETCH_SRC in parsedCsp.directives) {
+    violations.push(new Finding(
+        Type.DEPRECATED_DIRECTIVE,
+        'prefetch-src is deprecated since CSP3. ' +
+            'Be aware that this feature may cease to work at any time.',
+        Severity.INFO, Directive.PREFETCH_SRC));
+  }
   return violations;
 }
 

--- a/checks/security_checks_test.ts
+++ b/checks/security_checks_test.ts
@@ -413,6 +413,14 @@ describe('Test security checks', () => {
     expect(violations.length).toBe(1);
     expect(violations[0].severity).toBe(Severity.INFO);
   });
+  
+  it('CheckDeprecatedDirectivePrefetchSrc', () => {
+    const test = 'prefetch-src test';
+
+    const violations = checkCsp(test, securityChecks.checkDeprecatedDirective);
+    expect(violations.length).toBe(1);
+    expect(violations[0].severity).toBe(Severity.INFO);
+  });
 
   /** Tests for csp.securityChecks.checkNonceLength */
   it('CheckNonceLengthWithLongNonce', () => {


### PR DESCRIPTION
This addresses https://github.com/google/csp-evaluator/issues/69 and highlights `prefetch-src` as a deprecated directive. As outlined in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src#browser_compatibility