### PR TITLE
Add inline-speculation-rules to known keywords

### DIFF
--- a/csp.ts
+++ b/csp.ts
@@ -247,6 +247,7 @@ export enum Keyword {
   REPORT_SAMPLE = '\'report-sample\'',
   BLOCK = '\'block\'',
   ALLOW = '\'allow\'',
+  INLINE_SPECULATION_RULES = '\'inline-speculation-rules\'',
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse/issues/16319